### PR TITLE
make call to rpc getstakinginfo instead of getmininginfo and show the output on overview view

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "description": "light wallet built with electron and vue",
     "main": "src/index.js",
     "scripts": {
-        "start": "electron-forge start",
+        "start": "electron-forge start --inspect-electron",
         "package": "electron-forge package",
         "make": "electron-forge make",
         "publish": "electron-forge publish"

--- a/src/components/app-header.vue
+++ b/src/components/app-header.vue
@@ -26,7 +26,7 @@
           STAKING
         </div>
         <div class="status-item__icon">
-          <icon v-if="stakingStatus.netstakeweight > 0" icon="circle" width="11" height="11" class="icon active"></icon>
+          <icon v-if="stakingStatus.enabled > 0" icon="circle" width="11" height="11" class="icon active"></icon>
           <icon v-else icon="circle-o" width="11" height="11" class="icon"></icon>
         </div>
       </div>
@@ -57,51 +57,51 @@
   electra-logo_padding = 0 15px
 
   status-bar_padding = 0 15px
-  
+
   status-item_padding = 0 7px
   status-item__label_color = rgba(255,255,255,0.8)
   status-item__icon_color = #fff
   status-item__icon_opacity = 0.5
   status-item__icon--active_opacity = 1
-  
+
   .app-header
     display flex
     width 100%
     height 100%
-    
-    .electra-logo 
+
+    .electra-logo
       display flex
       width auto
       height 100%
       padding electra-logo_padding
-      
-      img 
+
+      img
         width auto
         height 55%
         margin auto 0
-        
-    .status-bar 
+
+    .status-bar
       display flex
       height 100%
       padding status-bar_padding
-      
+
   .status-item
     position relative
     top -2px
     margin auto 0
     padding status-item_padding
-    
+
     &__label
       display inline-block
       color status-item__label_color
-      
+
     &__icon
       display inline-block
       margin-left 5px
       color status-item__icon_color
-      
+
       .icon
-        opacity status-item__icon_opacity       
+        opacity status-item__icon_opacity
         &.active
           opacity status-item__icon--active_opacity
 

--- a/src/store/module-wallet.js
+++ b/src/store/module-wallet.js
@@ -22,14 +22,13 @@ const state = {
     moneysupply: 0
   },
   stakingStatus: {
+    enabled: false,
+    staking: false,
     blocks: 0,
     currentblocksize: 0,
+    weight: 0,
     netstakeweight: 0,
-    stakeweight: {
-      minimum: 0,
-      maximum: 0,
-      combined: 0
-    }
+    expectedtime: null
   },
   transactions: []
 }
@@ -56,7 +55,8 @@ const getters = {
   walletStatus: state => state.walletStatus,
   networkStatus: state => state.networkStatus,
   stakingStatus: state => state.stakingStatus,
-  transactions: state => state.transactions
+  transactions: state => state.transactions,
+  expectedTime: state => state.stakingStatus.expectedtime
 }
 
 const actions = {
@@ -72,7 +72,7 @@ const actions = {
         } else {
           const walletStatus = {
             balance: info.balance,
-            stake: info.stake,
+            stake: info.stake
           }
           const networkStatus = {
             ip: info.ip,
@@ -89,19 +89,18 @@ const actions = {
   },
   'update-staking-state' (module) {
     rpc
-      .exec('getmininginfo', (err, info) => {
+      .exec('getstakinginfo', (err, info) => {
         if (err) {
           console.error(err)
         } else {
           const stakingStatus = {
+            enabled: info.enabled,
+            staking: info.staking,
             blocks: info.blocks,
             currentblocksize: info.currentblocksize,
+            weight: info.weight,
             netstakeweight: info.netstakeweight,
-            stakeweight: {
-              minimum: info.stakeweight.minimum,
-              maximum: info.stakeweight.maximum,
-              combined: info.stakeweight.combined
-            }
+            expectedtime: info.expectedtime
           }
           module.commit('SET_STAKING_STATUS', stakingStatus)
         }
@@ -120,7 +119,7 @@ const actions = {
   'send-eca' (module, { address, amount }) {
     let amtStr = amount.toFixed(4)
     let amt = Number(amtStr)
-    rpc 
+    rpc
       .sendtoaddress(address, amt, (err, txid) => {
         if (err) {
           console.log(err)

--- a/src/views/view-overview.vue
+++ b/src/views/view-overview.vue
@@ -7,6 +7,9 @@
         Stake: <strong>{{ walletStatus.stake }}</strong><br>
         Connections: <strong>{{ networkStatus.connections }}</strong><br>
         Circulating supply: <strong>{{ networkStatus.moneysupply }}</strong><br>
+        Your weight: <strong>{{ stakingStatus.weight }}</strong></br>
+        Network weight: <strong> {{ stakingStatus.netstakeweight }}</strong></br>
+        Expected time to earn reward : <strong> {{ expectedTime }}</strong></br>
       </p>
     </div>
   </div>
@@ -20,6 +23,29 @@
       },
       networkStatus() {
         return this.$store.getters.networkStatus
+      },
+      stakingStatus() {
+        return this.$store.getters.stakingStatus
+      },
+      expectedTime() {
+        let expectedtime = this.stakingStatus.expectedtime
+        if (expectedtime < 60)
+        {
+          expectedtime = `${expectedtime} second(s)`
+        }
+        else if (expectedtime < 60*60)
+        {
+          expectedtime = `${expectedtime/60} minute(s)`
+        }
+        else if (expectedtime < 24*60*60)
+        {
+          expectedtime = `${expectedtime/(60*60)} hour(s)`
+        }
+        else
+        {
+          expectedtime = `${expectedtime/(60*60*24)} day(s)`
+        }
+        return parseInt(expectedtime, 10)
       }
     }
   }


### PR DESCRIPTION
## This PR contains the following changes:

- Use appropriate rpc i.e. instead of `getmininginfo` `getstakinginfo`.
- Add the staking info on the overview view.

Note: To use `getstakinginfo` command you need to add it in the kapitalize library inside the commands.js file. This is temporary until @ivangabriele finishes electra-js and we can have a standalone compiled version of electra for mac.